### PR TITLE
setup.nsi: Fix invalid registry path

### DIFF
--- a/activex/build/setup.nsi
+++ b/activex/build/setup.nsi
@@ -23,7 +23,7 @@
 !define REGPATH_LEGACYUPDATE_SETUP "Software\Hashbang Productions\Legacy Update\Setup"
 !define REGPATH_UNINSTSUBKEY       "Software\Microsoft\Windows\CurrentVersion\Uninstall\${NAME}"
 !define REGPATH_WUPOLICY           "Software\Policies\Microsoft\Windows\WindowsUpdate"
-!define REGPATH_WUAUPOLICY         "${REGPATH_WUAUPOLICY}\AU"
+!define REGPATH_WUAUPOLICY         "${REGPATH_WUPOLICY}\AU"
 !define REGPATH_WU                 "Software\Microsoft\Windows\CurrentVersion\WindowsUpdate"
 !define REGPATH_INETSETTINGS       "Software\Microsoft\Windows\CurrentVersion\Internet Settings"
 !define REGPATH_ZONEDOMAINS        "${REGPATH_INETSETTINGS}\ZoneMap\Domains"


### PR DESCRIPTION
REGPATH_WUAUPOLICY is currently set to itself and doesn't inherit REGPATH_WUPOLICY's path as a result.

Due to this, you'll end up with an error due to it being unable to set the registry key. In the case of Windows Server 2008 SP2 Enterprise at least (which is where I first encountered this), it'll result in no keys getting created for LegacyUpdate.

Tested on Windows 2000, XP, Vista, 2008, and 2008 R2. 😃